### PR TITLE
Use 'UK' and column comments

### DIFF
--- a/paracelsus/transformers/mermaid.py
+++ b/paracelsus/transformers/mermaid.py
@@ -35,7 +35,7 @@ class Mermaid:
             column_str += " UK"
 
         if column.comment:
-            column_str += f' "{column.comment}"'
+            options.append(f"{column.comment}")
 
         if column.nullable:
             options.append("nullable")

--- a/paracelsus/transformers/mermaid.py
+++ b/paracelsus/transformers/mermaid.py
@@ -20,6 +20,7 @@ class Mermaid:
         return output
 
     def _column(self, column: Column) -> str:
+        options = []
         column_str = f"{column.type} {column.name}"
 
         if column.primary_key:
@@ -29,13 +30,12 @@ class Mermaid:
                 column_str += " PK"
         elif len(column.foreign_keys) > 0:
             column_str += " FK"
+            options.append(f"Foreign key references {column.table.name}")
         elif column.unique:
             column_str += " UK"
 
         if column.comment:
-            column_str += f" \"{column.comment}\""
-
-        options = []
+            column_str += f' "{column.comment}"'
 
         if column.nullable:
             options.append("nullable")

--- a/paracelsus/transformers/mermaid.py
+++ b/paracelsus/transformers/mermaid.py
@@ -30,12 +30,11 @@ class Mermaid:
                 column_str += " PK"
         elif len(column.foreign_keys) > 0:
             column_str += " FK"
-            options.append(f"Foreign key references {column.table.name}")
         elif column.unique:
             column_str += " UK"
 
         if column.comment:
-            options.append(f"{column.comment}")
+            options.append(column.comment)
 
         if column.nullable:
             options.append("nullable")

--- a/paracelsus/transformers/mermaid.py
+++ b/paracelsus/transformers/mermaid.py
@@ -29,14 +29,16 @@ class Mermaid:
                 column_str += " PK"
         elif len(column.foreign_keys) > 0:
             column_str += " FK"
+        elif column.unique:
+            column_str += " UK"
+
+        if column.comment:
+            column_str += f" \"{column.comment}\""
 
         options = []
 
         if column.nullable:
             options.append("nullable")
-
-        if column.unique:
-            options.append("unique")
 
         if column.index:
             options.append("indexed")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,7 +23,7 @@ def metaclass():
         id = mapped_column(Uuid, primary_key=True, default=uuid4())
         author = mapped_column(ForeignKey(User.id), nullable=False)
         created = mapped_column(DateTime, nullable=False, default=datetime.utcnow())
-        live = mapped_column(Boolean, default=False)
+        live = mapped_column(Boolean, default=False, comment="True if post is published")
         content = mapped_column(Text, default="")
 
     class Comment(Base):

--- a/tests/transformers/test_mermaid.py
+++ b/tests/transformers/test_mermaid.py
@@ -4,7 +4,6 @@ from paracelsus.transformers.mermaid import Mermaid
 def test_mermaid(metaclass):
     mermaid = Mermaid(metaclass=metaclass)
     graph_string = str(mermaid)
-    print(graph_string)
 
     assert "users {" in graph_string
     assert "posts {" in graph_string
@@ -15,6 +14,6 @@ def test_mermaid(metaclass):
     assert "users ||--o{ comments : author" in graph_string
 
     assert "CHAR(32) author FK" in graph_string
-    assert 'CHAR(32) post FK "Foreign key references comments,nullable"' in graph_string
+    assert 'CHAR(32) post FK "nullable"' in graph_string
     assert 'BOOLEAN live "True if post is published,nullable"' in graph_string
     assert "DATETIME created" in graph_string

--- a/tests/transformers/test_mermaid.py
+++ b/tests/transformers/test_mermaid.py
@@ -4,6 +4,7 @@ from paracelsus.transformers.mermaid import Mermaid
 def test_mermaid(metaclass):
     mermaid = Mermaid(metaclass=metaclass)
     graph_string = str(mermaid)
+    print(graph_string)
 
     assert "users {" in graph_string
     assert "posts {" in graph_string
@@ -14,5 +15,6 @@ def test_mermaid(metaclass):
     assert "users ||--o{ comments : author" in graph_string
 
     assert "CHAR(32) author FK" in graph_string
-    assert 'CHAR(32) post FK "nullable"' in graph_string
+    assert 'CHAR(32) post FK "Foreign key references comments,nullable"' in graph_string
+    assert 'BOOLEAN live "True if post is published,nullable"' in graph_string
     assert "DATETIME created" in graph_string


### PR DESCRIPTION
Mermaid supports a key type of 'UK' for unique key, better to use that instead of adding a comment. Also, if the SQLAlchemy column has a comment assigned, we should add that to the Mermaid comment.

Here's the output for a table has has both a unique key and a comment in SQLAlchemy after the changes in this pull request:

```
  games {
    INTEGER id PK
    INTEGER away_team_id FK
    INTEGER home_team_id FK
    INTEGER league_id FK "nullable"
    INTEGER season_id FK
    INTEGER tracked_team_id FK
    INTEGER user_id FK
    INTEGER away_score
    VARCHAR(255) cuid UK "These are generated by clients and should be unique"
    DATE game_date
    INTEGER home_score
    VARCHAR(255) location
    BOOLEAN overtime
    BOOLEAN shootout
  }
```
