### PR TITLE
Support pyproject.toml features with older python

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -11,6 +11,7 @@ jobs:
   pytest:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         version: ["3.10", "3.11", "3.12"]
 

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version-file: ${{ matrix.version }}
+          python-version: ${{ matrix.version }}
 
       - name: Install Dependencies
         run: make install

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [3.10, 3.11, 3.12]
+        version: ["3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -10,12 +10,16 @@ env:
 jobs:
   pytest:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version: [3.10, 3.11, 3.12]
+
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v5
         with:
-          python-version-file: .python-version
+          python-version-file: ${{ matrix.version }}
 
       - name: Install Dependencies
         run: make install

--- a/paracelsus/pyproject.py
+++ b/paracelsus/pyproject.py
@@ -5,7 +5,7 @@ from typing import Any, Dict
 try:
     import tomllib
 except:  # noqa: E722
-    import toml as tomllib
+    import toml as tomllib  # type: ignore
 
 
 def get_pyproject_settings(dir: Path = Path(os.getcwd())) -> Dict[str, Any] | None:
@@ -15,6 +15,6 @@ def get_pyproject_settings(dir: Path = Path(os.getcwd())) -> Dict[str, Any] | No
         return None
 
     with open(pyproject, "rb") as f:
-        data = tomllib.load(f)
+        data = tomllib.loads(f.read().decode())
 
     return data.get("tool", {}).get("paracelsus", None)

--- a/paracelsus/pyproject.py
+++ b/paracelsus/pyproject.py
@@ -5,7 +5,7 @@ from typing import Any, Dict
 
 try:
     import tomllib
-except:
+except:  # noqa: E722
     import toml as tomllib
 
 

--- a/paracelsus/pyproject.py
+++ b/paracelsus/pyproject.py
@@ -1,5 +1,4 @@
 import os
-import tomllib
 from pathlib import Path
 from typing import Any, Dict
 

--- a/paracelsus/pyproject.py
+++ b/paracelsus/pyproject.py
@@ -3,6 +3,11 @@ import tomllib
 from pathlib import Path
 from typing import Any, Dict
 
+try:
+    import tomllib
+except:
+    import toml as tomllib
+
 
 def get_pyproject_settings(dir: Path = Path(os.getcwd())) -> Dict[str, Any] | None:
     pyproject = dir / "pyproject.toml"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,8 @@ authors = [{"name" = "Robert Hafner"}]
 dependencies = [
   "pydot",
   "sqlalchemy",
-  "typer"
+  "typer",
+  "toml; python_version < '3.11'",
 ]
 description = ""
 dynamic = ["version"]
@@ -27,7 +28,7 @@ dev = [
   "pytest-pretty",
   "ruamel.yaml",
   "ruff",
-  "toml-sort"
+  "toml-sort",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
   "pydot",
   "sqlalchemy",
   "typer",
-  "toml; python_version < '3.11'",
+  "toml; python_version < '3.11'"
 ]
 description = ""
 dynamic = ["version"]
@@ -28,7 +28,7 @@ dev = [
   "pytest-pretty",
   "ruamel.yaml",
   "ruff",
-  "toml-sort",
+  "toml-sort"
 ]
 
 [project.scripts]

--- a/tests/assets/example/models.py
+++ b/tests/assets/example/models.py
@@ -1,10 +1,12 @@
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from uuid import uuid4
 
 from sqlalchemy import Boolean, DateTime, ForeignKey, String, Text, Uuid
 from sqlalchemy.orm import mapped_column
 
 from .base import Base
+
+UTC = timezone.utc
 
 
 class User(Base):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 import os
 import shutil
 import tempfile
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from uuid import uuid4
 
@@ -9,6 +9,7 @@ import pytest
 from sqlalchemy import Boolean, DateTime, ForeignKey, String, Text, Uuid
 from sqlalchemy.orm import declarative_base, mapped_column
 
+UTC = timezone.utc
 
 @pytest.fixture
 def metaclass():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import declarative_base, mapped_column
 
 UTC = timezone.utc
 
+
 @pytest.fixture
 def metaclass():
     Base = declarative_base()


### PR DESCRIPTION
This should resolve #10, and also adds automated testing for more python versions.