### PR TITLE
Set minimum python version to 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dynamic = ["version"]
 license = {"file" = "LICENSE"}
 name = "paracelsus"
 readme = {file = "README.md", content-type = "text/markdown"}
+requires-python = ">= 3.10"
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
This project uses features only available in 3.10 and up, which should be explicit in the `pyproject.toml`.

resolves #12