### PR TITLE
Adjusting the transformers for schema support

### DIFF
--- a/paracelsus/transformers/dot.py
+++ b/paracelsus/transformers/dot.py
@@ -28,7 +28,7 @@ class Dot:
             for column in table.columns:
                 for foreign_key in column.foreign_keys:
                     key_parts = foreign_key.target_fullname.split(".")
-                    left_table = '.'.join(key_parts[:-1])
+                    left_table = ".".join(key_parts[:-1])
                     left_column = key_parts[-1]
 
                     # We don't add the connection to the fk table if the latter
@@ -40,7 +40,7 @@ class Dot:
                         )
                         continue
 
-                    edge = pydot.Edge(left_table.split('.')[-1], table.name)
+                    edge = pydot.Edge(left_table.split(".")[-1], table.name)
                     edge.set_label(column.name)
                     edge.set_dir("both")
 

--- a/paracelsus/transformers/dot.py
+++ b/paracelsus/transformers/dot.py
@@ -40,7 +40,7 @@ class Dot:
                         )
                         continue
 
-                    edge = pydot.Edge(left_table, table.name)
+                    edge = pydot.Edge(left_table.split('.')[-1], table.name)
                     edge.set_label(column.name)
                     edge.set_dir("both")
 

--- a/paracelsus/transformers/dot.py
+++ b/paracelsus/transformers/dot.py
@@ -28,8 +28,8 @@ class Dot:
             for column in table.columns:
                 for foreign_key in column.foreign_keys:
                     key_parts = foreign_key.target_fullname.split(".")
-                    left_table = key_parts[0]
-                    left_column = key_parts[1]
+                    left_table = '.'.join(key_parts[:-1])
+                    left_column = key_parts[-1]
 
                     # We don't add the connection to the fk table if the latter
                     # is not included in our graph.

--- a/paracelsus/transformers/mermaid.py
+++ b/paracelsus/transformers/mermaid.py
@@ -66,8 +66,8 @@ class Mermaid:
 
         for foreign_key in column.foreign_keys:
             key_parts = foreign_key.target_fullname.split(".")
-            left_table = key_parts[0]
-            left_column = key_parts[1]
+            left_table = '.'.join(key_parts[:-1])
+            left_column = key_parts[-1]
             left_operand = ""
 
             # We don't add the connection to the fk table if the latter

--- a/paracelsus/transformers/mermaid.py
+++ b/paracelsus/transformers/mermaid.py
@@ -66,7 +66,7 @@ class Mermaid:
 
         for foreign_key in column.foreign_keys:
             key_parts = foreign_key.target_fullname.split(".")
-            left_table = '.'.join(key_parts[:-1])
+            left_table = ".".join(key_parts[:-1])
             left_column = key_parts[-1]
             left_operand = ""
 

--- a/paracelsus/transformers/mermaid.py
+++ b/paracelsus/transformers/mermaid.py
@@ -85,7 +85,7 @@ class Mermaid:
             else:
                 left_operand = "}o"
 
-            output += f"  {left_table} {left_operand}--{right_operand} {right_table} : {column_name}\n"
+            output += f"  {left_table.split('.')[-1]} {left_operand}--{right_operand} {right_table} : {column_name}\n"
         return output
 
     def __str__(self) -> str:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -95,7 +95,7 @@ users [label=<
         <tr><td align="left">VARCHAR(100)</td><td align="left">display_name</td><td></td></tr>
         <tr><td align="left">DATETIME</td><td align="left">created</td><td></td></tr>
     </table>
->, margin=0, shape=none];
+>, shape=none, margin=0];
 posts [label=<
     <table border="0" cellborder="1" cellspacing="0" cellpadding="4">
         <tr><td colspan="3" bgcolor="lightblue"><b>posts</b></td></tr>
@@ -105,8 +105,8 @@ posts [label=<
         <tr><td align="left">BOOLEAN</td><td align="left">live</td><td></td></tr>
         <tr><td align="left">TEXT</td><td align="left">content</td><td></td></tr>
     </table>
->, margin=0, shape=none];
-users -- posts  [arrowhead=crow, arrowtail=none, dir=both, label=author];
+>, shape=none, margin=0];
+users -- posts [label=author, dir=both, arrowhead=crow, arrowtail=none];
 comments [label=<
     <table border="0" cellborder="1" cellspacing="0" cellpadding="4">
         <tr><td colspan="3" bgcolor="lightblue"><b>comments</b></td></tr>
@@ -117,8 +117,8 @@ comments [label=<
         <tr><td align="left">BOOLEAN</td><td align="left">live</td><td></td></tr>
         <tr><td align="left">TEXT</td><td align="left">content</td><td></td></tr>
     </table>
->, margin=0, shape=none];
-posts -- comments  [arrowhead=crow, arrowtail=none, dir=both, label=post];
-users -- comments  [arrowhead=crow, arrowtail=none, dir=both, label=author];
+>, shape=none, margin=0];
+posts -- comments [label=post, dir=both, arrowhead=crow, arrowtail=none];
+users -- comments [label=author, dir=both, arrowhead=crow, arrowtail=none];
 }
 """

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -18,9 +18,9 @@ def dot_assert(output: str) -> None:
     assert '<tr><td colspan="3" bgcolor="lightblue"><b>posts</b></td></tr>' in output
     assert '<tr><td colspan="3" bgcolor="lightblue"><b>comments</b></td></tr>' in output
 
-    assert "users -- posts  [arrowhead=crow, arrowtail=none, dir=both, label=author];" in output
-    assert "posts -- comments  [arrowhead=crow, arrowtail=none, dir=both, label=post];" in output
-    assert "users -- comments  [arrowhead=crow, arrowtail=none, dir=both, label=author];" in output
+    assert "users -- posts [label=author, dir=both, arrowhead=crow, arrowtail=none];" in output
+    assert "posts -- comments [label=post, dir=both, arrowhead=crow, arrowtail=none];" in output
+    assert "users -- comments [label=author, dir=both, arrowhead=crow, arrowtail=none];" in output
 
     assert '<tr><td align="left">CHAR(32)</td><td align="left">author</td><td>Foreign Key</td></tr>' in output
     assert '<tr><td align="left">CHAR(32)</td><td align="left">post</td><td>Foreign Key</td></tr>' in output


### PR DESCRIPTION
When using a database with a schema defined in the SQLAlchemy metadata the resulting value of `foreign_key.target_fullname` would be `[schema].[table_name].[column_name]` The previous implementation split `foreign_key.target_fullname` on the `.` and defined `left_table` as element `[0]` (`[schema]`) and `left_column` as element `[1]` (`[table_name]`). This splitting does not take into account the possibility of a schema. 

The `table_name` values defined in `self.metadata.tables` are stored as `[schema].[table_name]`. Therefore, the logic to enforce the existence of the table on the left side was always `False` when a schema is present because the names was not the same. 

Changing the assumption to be that the last element `[-1]` of the resulting array when splitting `foreign_key.target_fullname` on a `.` is the column name, ensures that regardless of the use of a schema that `left-column` will be the correct value for `column_name`. Additionally, since the value of the table name stored in  `self.metadata.tables` is `foreign_key.target_fullname` less `.[column_name]`, by rejoining the elements of the split less the last element `[:-1]` by a `.` results in the correct value for `left_table` regardless of schema usage.