### PR TITLE
End graph cli stdout with a single trailing newline

### DIFF
--- a/paracelsus/cli.py
+++ b/paracelsus/cli.py
@@ -101,18 +101,17 @@ def graph(
     if "imports" in settings:
         import_module.extend(settings["imports"])
 
-    typer.echo(
-        get_graph_string(
-            base_class_path=base_class,
-            import_module=import_module,
-            include_tables=set(include_tables + settings.get("include_tables", [])),
-            exclude_tables=set(exclude_tables + settings.get("exclude_tables", [])),
-            python_dir=python_dir,
-            format=format.value,
-            column_sort=column_sort,
-            omit_comments=omit_comments,
-        )
+    graph_string = get_graph_string(
+        base_class_path=base_class,
+        import_module=import_module,
+        include_tables=set(include_tables + settings.get("include_tables", [])),
+        exclude_tables=set(exclude_tables + settings.get("exclude_tables", [])),
+        python_dir=python_dir,
+        format=format.value,
+        column_sort=column_sort,
+        omit_comments=omit_comments,
     )
+    typer.echo(graph_string, nl=not graph_string.endswith("\n"))
 
 
 @app.command(help="Create a graph and inject it as a code field into a markdown file.")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -12,6 +12,8 @@ def mermaid_assert(output: str) -> None:
     assert 'BOOLEAN live "True if post is published,nullable"' in output
     assert "DATETIME created" in output
 
+    trailing_newline_assert(output)
+
 
 def dot_assert(output: str) -> None:
     assert '<tr><td colspan="3" bgcolor="lightblue"><b>users</b></td></tr>' in output
@@ -25,3 +27,15 @@ def dot_assert(output: str) -> None:
     assert '<tr><td align="left">CHAR(32)</td><td align="left">author</td><td>Foreign Key</td></tr>' in output
     assert '<tr><td align="left">CHAR(32)</td><td align="left">post</td><td>Foreign Key</td></tr>' in output
     assert '<tr><td align="left">DATETIME</td><td align="left">created</td><td></td></tr>' in output
+
+    trailing_newline_assert(output)
+
+
+def trailing_newline_assert(output: str) -> None:
+    """
+    Check that the output ends with a single newline.
+    This reduces end user linter rewrites,
+    e.g. from pre-commit's end-of-file-fixer hook.
+    """
+    assert output.endswith("\n")
+    assert not output.endswith("\n\n")


### PR DESCRIPTION
as opposed to two trailing newlines.

minor but avoids linters from having to rewrite stdout redirected to committed files