### PR TITLE
Feat: use the base class config in pyproject.toml when injecting

### DIFF
--- a/paracelsus/cli.py
+++ b/paracelsus/cli.py
@@ -127,9 +127,9 @@ def inject(
         ),
     ],
     base_class_path: Annotated[
-        str,
+        Optional[str],
         typer.Argument(help="The SQLAlchemy base class used by the database to graph."),
-    ],
+    ] = None,
     replace_begin_tag: Annotated[
         str,
         typer.Option(help=""),
@@ -187,12 +187,14 @@ def inject(
     ] = OMIT_COMMENTS_DEFAULT,
 ):
     settings = get_pyproject_settings()
+    base_class = get_base_class(base_class_path, settings)
+
     if "imports" in settings:
         import_module.extend(settings["imports"])
 
     # Generate Graph
     graph = get_graph_string(
-        base_class_path=base_class_path,
+        base_class_path=base_class,
         import_module=import_module,
         include_tables=set(include_tables + settings.get("include_tables", [])),
         exclude_tables=set(exclude_tables + settings.get("exclude_tables", [])),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 from typing import Literal
 import pytest
+from unittest.mock import Mock
+from unittest import mock
 
 from typer.testing import CliRunner
 
@@ -134,6 +136,20 @@ def test_inject_column_sort(package_path: Path, column_sort_arg: Literal["key-ba
     )
     assert result.exit_code == 0
 
+    with open(package_path / "README.md") as fp:
+        readme = fp.read()
+        mermaid_assert(readme)
+
+
+@mock.patch("paracelsus.cli.get_pyproject_settings", return_value={"base": "example.base:Base", "imports": ["example.models"]})
+def test_inject_pyproject_configuration(mock_get_pyproject_settings: Mock, package_path: Path):
+    """Test that the pyproject.toml configuration is used when base class path is not passed as argument."""
+    result = runner.invoke(
+        app,
+        ["inject", str(package_path / "README.md")],
+    )
+    assert result.exit_code == 0
+    
     with open(package_path / "README.md") as fp:
         readme = fp.read()
         mermaid_assert(readme)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -141,7 +141,9 @@ def test_inject_column_sort(package_path: Path, column_sort_arg: Literal["key-ba
         mermaid_assert(readme)
 
 
-@mock.patch("paracelsus.cli.get_pyproject_settings", return_value={"base": "example.base:Base", "imports": ["example.models"]})
+@mock.patch(
+    "paracelsus.cli.get_pyproject_settings", return_value={"base": "example.base:Base", "imports": ["example.models"]}
+)
 def test_inject_pyproject_configuration(mock_get_pyproject_settings: Mock, package_path: Path):
     """Test that the pyproject.toml configuration is used when base class path is not passed as argument."""
     result = runner.invoke(
@@ -149,10 +151,12 @@ def test_inject_pyproject_configuration(mock_get_pyproject_settings: Mock, packa
         ["inject", str(package_path / "README.md")],
     )
     assert result.exit_code == 0
-    
+
     with open(package_path / "README.md") as fp:
         readme = fp.read()
         mermaid_assert(readme)
+
+    mock_get_pyproject_settings.assert_called_once()
 
 
 def test_version():


### PR DESCRIPTION
Currently, the `paracelsus graph` command correctly loads the base path config from the `pyproject.toml `where it is not provided in the command args.

The `paracelsus inject` command does not behave in the same way - it ignores the `base` setting in `pyproject.toml`.

I've changed this and added a test. Let me know if you don't agree that this should be the behaviour!

Also - great little lib, thanks @tedivm !