### PR TITLE
Feature: Add values for enum types in a comment

### DIFF
--- a/tests/transformers/test_mermaid.py
+++ b/tests/transformers/test_mermaid.py
@@ -1,3 +1,6 @@
+import sqlalchemy
+from sqlalchemy import Column, Enum, MetaData, Table
+
 from paracelsus.transformers.mermaid import Mermaid
 
 from ..utils import mermaid_assert
@@ -22,3 +25,19 @@ def test_mermaid_keep_comments(metaclass):
 def test_mermaid_omit_comments(metaclass):
     mermaid = Mermaid(metaclass=metaclass, column_sort="key-based", omit_comments=True)
     assert "True if post is published" not in str(mermaid)
+
+
+def test_mermaid_enum_values_present():
+    metadata = MetaData()
+    status_enum = Enum("draft", "published", "archived", name="status_enum")
+    table = Table(
+        "post",
+        metadata,
+        Column("id", sqlalchemy.Integer, primary_key=True),
+        Column("status", status_enum, nullable=True),
+    )
+    mermaid = Mermaid(metaclass=metadata, column_sort="key-based")
+    status_column = table.columns["status"]
+    column_str = mermaid._column(status_column)
+
+    assert "values: draft, published, archived" in column_str


### PR DESCRIPTION
This pull request improves how Enum columns are represented in Mermaid diagrams and adds corresponding test coverage. The main enhancement is that Enum columns now display their possible values in the generated output, making schema diagrams more informative. 

**Mermaid ENUM rendering improvements:**

* Updated the `_column` method in `paracelsus/transformers/mermaid.py` to detect `sqlalchemy.Enum` columns and render their type as `ENUM`, including their possible values in the output. [[1]](diffhunk://#diff-d89905d3431e7953a616c02858e533a9c79aee80234d89e12923b4d67667ef32L32-R35) [[2]](diffhunk://#diff-d89905d3431e7953a616c02858e533a9c79aee80234d89e12923b4d67667ef32L53-R67)

**Test coverage:**

* Added a new test `test_mermaid_enum_values_present` in `tests/transformers/test_mermaid.py` to verify that Enum columns include their possible values in the Mermaid output.