### PR TITLE
Display diff when `check` fails, Sort tables in Mermaid output

### DIFF
--- a/paracelsus/cli.py
+++ b/paracelsus/cli.py
@@ -1,6 +1,7 @@
 import re
 import sys
 from dataclasses import asdict
+from difflib import unified_diff
 from pathlib import Path
 from textwrap import dedent
 from typing import List, Optional
@@ -307,7 +308,20 @@ def inject(
             sys.exit(0)
         else:
             # If content is different then we failed the test.
-            typer.echo("Changes detected.")
+            # Generate unified diff
+            diff = unified_diff(
+                old_content.splitlines(keepends=True),
+                new_content.splitlines(keepends=True),
+                fromfile='old',
+                tofile='new',
+                lineterm=''
+            )
+            
+            typer.echo("Changes detected. Diff:")
+            typer.echo("")
+            for line in diff:
+                typer.echo(line.rstrip())
+            
             sys.exit(1)
     else:
         # Dump newly generated contents back to file.

--- a/paracelsus/cli.py
+++ b/paracelsus/cli.py
@@ -312,16 +312,16 @@ def inject(
             diff = unified_diff(
                 old_content.splitlines(keepends=True),
                 new_content.splitlines(keepends=True),
-                fromfile='old',
-                tofile='new',
-                lineterm=''
+                fromfile="old",
+                tofile="new",
+                lineterm="",
             )
-            
+
             typer.echo("Changes detected. Diff:")
             typer.echo("")
             for line in diff:
                 typer.echo(line.rstrip())
-            
+
             sys.exit(1)
     else:
         # Dump newly generated contents back to file.

--- a/paracelsus/transformers/mermaid.py
+++ b/paracelsus/transformers/mermaid.py
@@ -173,10 +173,10 @@ class Mermaid:
             """)
             output = yaml_front_matter + output
         output += "erDiagram\n"
-        for table in self.metadata.tables.values():
+        for table in sorted(self.metadata.tables.values(), key=lambda t: t.name):
             output += self._table(table)
 
-        for table in self.metadata.tables.values():
+        for table in sorted(self.metadata.tables.values(), key=lambda t: t.name):
             for column in table.columns.values():
                 if len(column.foreign_keys) > 0:
                     output += self._relationships(column)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,10 +68,13 @@ def package_path() -> Generator[Path, None, None]:
 @pytest.fixture()
 def mermaid_full_string_preseve_column_sort() -> str:
     return """erDiagram
-  users {
+  comments {
     CHAR(32) id PK
-    VARCHAR(100) display_name "nullable"
     DATETIME created
+    CHAR(32) post FK "nullable"
+    CHAR(32) author FK
+    BOOLEAN live "nullable"
+    TEXT content "nullable"
   }
 
   posts {
@@ -82,18 +85,15 @@ def mermaid_full_string_preseve_column_sort() -> str:
     TEXT content "nullable"
   }
 
-  comments {
+  users {
     CHAR(32) id PK
+    VARCHAR(100) display_name "nullable"
     DATETIME created
-    CHAR(32) post FK "nullable"
-    CHAR(32) author FK
-    BOOLEAN live "nullable"
-    TEXT content "nullable"
   }
 
-  users ||--o{ posts : author
   posts ||--o{ comments : post
   users ||--o{ comments : author
+  users ||--o{ posts : author
 """
 
 
@@ -153,18 +153,18 @@ def fixture_expected_mermaid_smaller_graph() -> str:
                 layout: dagre
         ---
         erDiagram
-          users {
-            CHAR(32) id PK
-            DATETIME created
-            VARCHAR(100) display_name "nullable"
-          }
-        
           posts {
             CHAR(32) id PK
             CHAR(32) author FK
             TEXT content "nullable"
             DATETIME created
             BOOLEAN live "True if post is published,nullable"
+          }
+        
+          users {
+            CHAR(32) id PK
+            DATETIME created
+            VARCHAR(100) display_name "nullable"
           }
         
           users ||--o{ posts : author
@@ -191,10 +191,13 @@ def fixture_expected_mermaid_complete_graph() -> str:
                 layout: dagre
         ---
         erDiagram
-          users {
+          comments {
             CHAR(32) id PK
+            CHAR(32) author FK
+            CHAR(32) post FK "nullable"
+            TEXT content "nullable"
             DATETIME created
-            VARCHAR(100) display_name "nullable"
+            BOOLEAN live "nullable"
           }
         
           posts {
@@ -205,18 +208,15 @@ def fixture_expected_mermaid_complete_graph() -> str:
             BOOLEAN live "True if post is published,nullable"
           }
         
-          comments {
+          users {
             CHAR(32) id PK
-            CHAR(32) author FK
-            CHAR(32) post FK "nullable"
-            TEXT content "nullable"
             DATETIME created
-            BOOLEAN live "nullable"
+            VARCHAR(100) display_name "nullable"
           }
         
-          users ||--o{ posts : author
           posts ||--o{ comments : post
           users ||--o{ comments : author
+          users ||--o{ posts : author
         
         ```
         <!-- END_SQLALCHEMY_DOCS -->


### PR DESCRIPTION
When generating Mermaid, be sure that tables are sorted alphabetically.  This ensures that the `--check` flag will always succed if the diagrams are the same.  The `--check` flag just checks for pure string equality, so we must ensure that generated diagram text is always the same.

Also updated the `--check` command to output the difference between the old and new outputs to give more information on what needs to be fixed.